### PR TITLE
Enable wall placement and dimension annotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,13 +40,15 @@
         alt="Demo glTF/GLB model"
         ar
         ar-modes="webxr scene-viewer quick-look"
+        ar-placement="wall"
         camera-controls
         touch-action="pan-y"
         tone-mapping="neutral"
         shadow-intensity="1"
         exposure="1"
         poster=""
-        loading="eager">
+        loading="eager"
+        show-dimensions>
       </model-viewer>
     </main>
 
@@ -89,6 +91,7 @@
       }
 
       mv.addEventListener('load', populateVariants);
+      mv.addEventListener('load', () => { mv.showDimensions = true; });
       sel.addEventListener('change', () => { mv.variantName = sel.value || null; });
       exposure.addEventListener('input', () => { mv.exposure = parseFloat(exposure.value); });
       shadow.addEventListener('input', () => { mv.shadowIntensity = parseFloat(shadow.value); });


### PR DESCRIPTION
## Summary
- enable wall AR placement
- display dimension annotations for the model

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b62a1f3f48328a72b60efb200390e